### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,13 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines


### PR DESCRIPTION
This pull request introduces several configuration updates to the repository's linting and formatting workflows. The main focus is on customizing markdown linting rules and disabling certain linter validations in the CI environment.

Linter configuration updates:

* [`.github/PSModule.yml`](diffhunk://#diff-928165ed381f1982eb8f9746a59a2829db4abc8a28eddb8c109e12bb033ff96aR22-R31): Added a `Linter` section to the CI configuration, explicitly disabling various linter checks (e.g., Biome format and lint, GitHub Actions Zizmor, JSCPD, and Prettier validations for JSON, Markdown, and YAML) by setting their environment variables to `false`.

Markdown linting rule adjustments:

* [`.github/linters/.markdown-lint.yml`](diffhunk://#diff-2fd3619d2b7372123257bc21645edb90c24293e66babbc6053033a89e21bab34R16-R18): Disabled the `MD024` rule to allow duplicate headings (useful for repeated "INPUTS" and "OUTPUTS" sections), and made a minor formatting adjustment to the `MD026` punctuation list.